### PR TITLE
Catch 'threadWait: invalid argument (Bad file descriptor)'

### DIFF
--- a/lattest-lib/src/System/IO/Streams/Synchronized.hs
+++ b/lattest-lib/src/System/IO/Streams/Synchronized.hs
@@ -26,7 +26,8 @@ import Control.Concurrent.STM(STM, orElse, retry)
 import Control.Concurrent.STM.TQueue(TQueue, newTQueueIO, writeTQueue, readTQueue, isEmptyTQueue, unGetTQueue)
 import Control.Concurrent.STM.TMVar(TMVar, newTMVarIO, takeTMVar, isEmptyTMVar)
 import Control.Concurrent.STM.TVar(TVar, newTVarIO, readTVar, writeTVar)
-import Control.Exception(throwIO, Exception)
+import GHC.IO.Exception (ioe_location, ioe_errno)
+import Control.Exception(throwIO, Exception, catchJust)
 import Control.Monad (void)
 import Data.List(singleton)
 import Data.Maybe(isJust)
@@ -35,6 +36,7 @@ import System.IO.Streams (InputStream, OutputStream, makeInputStream, makeOutput
 import qualified System.IO.Streams.Combinators as Streams (map)
 import qualified System.IO.Streams as Streams (read, write, writeTo)
 import Control.Monad.Extra((||^), (&&^))
+import Foreign.C.Error (eBADF, Errno (Errno))
 
 data TInputStream a = TInputStream {
     tRead :: STM (Maybe a),
@@ -146,8 +148,18 @@ fromInputStreamBuffered :: InputStream a -> IO (TInputStream a)
 fromInputStreamBuffered is = do
     buffer <- newTQueueIO
     bufferOS <- makeOutputStream $ atomically . writeTQueue buffer -- an intermediate output stream to write to the queue
-    void $ forkIO $ connect is bufferOS -- move items from the original adapter into the buffer in a separate thread
+    void $ forkIO $ catchSocketClosed $ connect is bufferOS -- move items from the original adapter into the buffer in a separate thread
     fromBuffer buffer
+ where
+   -- catches "threadWait: invalid argument (Bad file descriptor)"
+   -- which is thrown when the socket is closed while this thread is running, e.g. on Adaptor.close()
+   -- The alternative solution is to keep track of the threadID given by forkIO,
+   -- and explicitly stop the thread before closing the socket.
+   catchSocketClosed forkedThread = catchJust threadwaitinvalid forkedThread pure
+   threadwaitinvalid e
+    | ioe_location e == "threadWait"
+    , fmap Errno (ioe_errno e) == Just eBADF = Just ()
+    | otherwise = Nothing
 
 mapUnbuffered :: (a -> b) -> (b -> a) -> TInputStream a -> TInputStream b -- we need an inverse to push a's back to the original TInputStream of b's
 mapUnbuffered f f' tis = TInputStream { -- FIXME either remove or wrap in withClosedState


### PR DESCRIPTION
Some tests (the 'testJSONSocketAdapter*' ones) threw an exception at the end, because we close the socket while the corresponding thread is still listening.

This PR just catches that exception, the more rigorous fix would be to keep track of the threadID and kill it before closing the socket.