### PR TITLE
0.1.1: fixes for small issues arising from running examples

### DIFF
--- a/lattest-lib/CHANGELOG.md
+++ b/lattest-lib/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to the
 
 ## Unreleased
 
+## 0.1.1 - 2026-07-15
+Bugfix patch: adds instance OrdTraversable FreeLattice, and properly kills the reading thread before its socket is closed.
+
 ## 0.1.0.0 - 2026-07-14
 First release
 

--- a/lattest-lib/make-release.md
+++ b/lattest-lib/make-release.md
@@ -1,4 +1,8 @@
-- Check the changelog, increment version number, check version bounds on dependencies, etc.
+# Check:
+- changelog
+- increment version number
+- version bounds on dependencies
+- run the examples
 
 # HACKAGE:
 - Make an updated lattest-lib.cabal (e.g. by invoking stack)

--- a/lattest-lib/package.yaml
+++ b/lattest-lib/package.yaml
@@ -1,5 +1,5 @@
 name:                lattest-lib
-version:             0.1.0.0
+version:             0.1.1
 synopsis: Model-based testing framework
 description: |
   Welcome to Lattest, the latest attested lattice testing tech!

--- a/lattest-lib/src/Lattest/Adapter/StandardAdapters.hs
+++ b/lattest-lib/src/Lattest/Adapter/StandardAdapters.hs
@@ -74,7 +74,7 @@ import Data.Time.Clock(getCurrentTime,addUTCTime,diffUTCTime,NominalDiffTime,sec
 
 import Debug.Trace(trace) -- FIXME find a better alternative
 
-import GHC.Conc(forkIO, newTVarIO, TVar, retry, atomically, writeTVar, readTVar, STM, orElse)
+import GHC.Conc(forkIO, newTVarIO, TVar, retry, atomically, writeTVar, readTVar, STM, orElse, killThread)
 
 import Network.Socket(HostName, PortNumber)
 import Network.Utils (niceSocketsDo, connectTCP)
@@ -566,11 +566,12 @@ connectSocketAdapterWith :: SocketSettings act i -> IO (Adapter ByteString ByteS
 connectSocketAdapterWith settings = niceSocketsDo $ do
     socket <- connectTCP (hostName settings) (portNumber settings)
     (actionBytes, inputCommandBytes) <- socketToStreams socket
-    forkedActionBytes <- fromInputStreamBuffered actionBytes
+    (threadid, forkedActionBytes) <- fromInputStreamBuffered actionBytes
     return $ Adapter {
         inputCommandsToSut = inputCommandBytes,
         actionsFromSut = forkedActionBytes,
-        close = Socket.gracefulClose socket 1000
+        -- when the adapter is closed, we first kill the thread, to prevent it from throwing errors when we kill its socket
+        close = killThread threadid >> Socket.gracefulClose socket 1000
     }
 
 -- | Create an adapter by connecting to a server socket, with the default settings, and sending inputs and reading outputs in JSON format.

--- a/lattest-lib/src/Lattest/Model/BoundedMonad.hs
+++ b/lattest-lib/src/Lattest/Model/BoundedMonad.hs
@@ -190,6 +190,10 @@ isProperSupersetOfAny sets a = any (isProperSupersetOf a) (Set.toList sets)
 instance OM.OrdFunctor FreeLattice where
     ordMap f (FreeLattice x) = FreeLattice $ Set.map (Set.map f) x
 
+instance OM.OrdTraversable FreeLattice where
+    ordTraverse f (FreeLattice x) = FreeLattice <$> ordTraverse (ordTraverse f) x
+    ordSequenceA (FreeLattice x) = FreeLattice <$> ordTraverse ordSequenceA x
+
 instance Ord a => JoinSemiLattice (FreeLattice a) where
     (FreeLattice x) \/ (FreeLattice y) = FreeLattice $ Set.map Set.unions $ nAryCartesianProduct $ Set.fromList [x,y]
 

--- a/lattest-lib/src/Lattest/Streams/Synchronized.hs
+++ b/lattest-lib/src/Lattest/Streams/Synchronized.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TupleSections #-}
 module Lattest.Streams.Synchronized (
 TInputStream,
 read,
@@ -26,16 +27,14 @@ import Control.Concurrent.STM(STM, retry)
 import Control.Concurrent.STM.TQueue(TQueue, newTQueueIO, writeTQueue, readTQueue, isEmptyTQueue, unGetTQueue)
 import Control.Concurrent.STM.TMVar(TMVar, takeTMVar, isEmptyTMVar)
 import Control.Concurrent.STM.TVar(newTVarIO, readTVar, writeTVar)
-import GHC.IO.Exception (ioe_location, ioe_errno)
-import Control.Exception(throwIO, Exception, catchJust)
+import Control.Exception(throwIO, Exception)
 import Control.Monad (void, when)
 import Data.List(singleton)
 
-import GHC.Conc (atomically, forkIO)
+import GHC.Conc (atomically, forkIO, ThreadId)
 import System.IO.Streams (InputStream, OutputStream, makeOutputStream, connect)
 import qualified System.IO.Streams as Streams (write)
 import Control.Monad.Extra((||^))
-import Foreign.C.Error (eBADF, Errno (Errno))
 
 data TInputStream a = TInputStream {
     tRead :: STM (Maybe a),
@@ -141,22 +140,12 @@ fromBuffer buffer = withClosedState $ TInputStream {
 
 -- a synchronized input stream that reads from the given input stream. A monitoring thread reads the given input stream and buffers the inputs on the background
 -- TODO support a bound for the buffer
-fromInputStreamBuffered :: InputStream a -> IO (TInputStream a)
+fromInputStreamBuffered :: InputStream a -> IO (ThreadId, TInputStream a)
 fromInputStreamBuffered is = do
     buffer <- newTQueueIO
     bufferOS <- makeOutputStream $ atomically . writeTQueue buffer -- an intermediate output stream to write to the queue
-    void $ forkIO $ catchSocketClosed $ connect is bufferOS -- move items from the original adapter into the buffer in a separate thread
-    fromBuffer buffer
- where
-   -- catches "threadWait: invalid argument (Bad file descriptor)"
-   -- which is thrown when the socket is closed while this thread is running, e.g. on Adaptor.close()
-   -- The alternative solution is to keep track of the threadID given by forkIO,
-   -- and explicitly stop the thread before closing the socket.
-   catchSocketClosed forkedThread = catchJust threadwaitinvalid forkedThread pure
-   threadwaitinvalid e
-    | ioe_location e == "threadWait"
-    , fmap Errno (ioe_errno e) == Just eBADF = Just ()
-    | otherwise = Nothing
+    threadid <- forkIO $ connect is bufferOS -- move items from the original adapter into the buffer in a separate thread
+    (threadid,) <$> fromBuffer buffer
 
 mapUnbuffered :: (a -> b) -> (b -> a) -> TInputStream a -> TInputStream b -- we need an inverse to push a's back to the original TInputStream of b's
 mapUnbuffered f f' tis = TInputStream { -- FIXME either remove or wrap in withClosedState


### PR DESCRIPTION
- properly kill a thread when we close the socket it reads from, instead of trying to catch specific errors. The error we were catching earlier worked for the ones thrown in tests, but running one of the examples repeatedly gave me one of ~5 other errors nondeterministically. This seems like the principled solution.
- Was missing an OrdTraversable instance for FreeLattice, which also showed up when trying to run an example. We should start running the examples as part of the CI.
- I already made a hackage release for this, because I'm about to go on holiday.