### PR TITLE
update examples to use hackage lattest-lib-0.1.1

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -17,6 +17,7 @@ jobs:
     name: testsuite
 
     runs-on: ubuntu-latest
+    timeout-minutes: 45
 
     steps:
     - uses: actions/checkout@v4
@@ -77,3 +78,78 @@ jobs:
       run: |
         cd lattest-lib
         stack test --system-ghc --stack-yaml "stack-${{ matrix.ghcversion }}.yaml"
+
+    - name: Set up JDK for example SUTs
+      uses: actions/setup-java@v4
+      with:
+        distribution: temurin
+        java-version: '21'
+        cache: maven
+
+    - name: Point examples at the local lattest-lib build
+      run: |
+        set -euo pipefail
+        resolver_line=$(grep '^resolver:' "lattest-lib/stack-${{ matrix.ghcversion }}.yaml")
+        for exdir in examples/*/; do
+          ex=$(basename "$exdir")
+          [ -f "$exdir/stack.yaml" ] || continue
+          sed -i -E \
+            -e "s|^resolver:.*|$resolver_line|" \
+            -e "s|^- lattest-lib-[0-9]+(\.[0-9]+)*\$|- ../../lattest-lib|" \
+            "$exdir/stack.yaml"
+        done
+
+    - name: Run examples against their Java SUTs
+      run: |
+        set -uo pipefail
+        for exdir in examples/*/; do
+          ex=$(basename "$exdir")
+          [ -f "$exdir/stack.yaml" ] || continue
+          echo "::group::$ex"
+          sut_log="$RUNNER_TEMP/$ex-sut.log"
+          sut_pid=""
+
+          if [ -f "$exdir/sut/pom.xml" ]; then
+            timeout -k 30 300 bash -c 'cd "$1/sut" && mvn -q -B install' _ "$exdir"
+            if [ $? -ne 0 ]; then
+              echo "::endgroup::"
+              echo "Building the SUT for $ex failed"
+              exit 1
+            fi
+
+            (cd "$exdir/sut" && mvn -q -B exec:java > "$sut_log" 2>&1) &
+            sut_pid=$!
+
+            ready=0
+            for i in $(seq 1 30); do
+              if (exec 3<>/dev/tcp/127.0.0.1/2929) 2>/dev/null; then
+                exec 3<&- 3>&-
+                ready=1
+                break
+              fi
+              sleep 1
+            done
+            if [ "$ready" -ne 1 ]; then
+              echo "SUT for $ex never opened port 2929"
+              cat "$sut_log" || true
+              kill -9 "$sut_pid" 2>/dev/null || true
+              echo "::endgroup::"
+              exit 1
+            fi
+          fi
+
+          timeout -k 30 600 bash -c 'cd "$1" && stack build --system-ghc --stack-yaml stack.yaml && stack run --system-ghc --stack-yaml stack.yaml' _ "$exdir"
+          status=$?
+
+          if [ -n "$sut_pid" ]; then
+            kill -9 "$sut_pid" 2>/dev/null || true
+            wait "$sut_pid" 2>/dev/null || true
+          fi
+          echo "::endgroup::"
+
+          if [ "$status" -ne 0 ]; then
+            echo "Example $ex failed"
+            [ -f "$sut_log" ] && cat "$sut_log"
+            exit 1
+          fi
+        done

--- a/examples/example-conjunction/src/Lib.hs
+++ b/examples/example-conjunction/src/Lib.hs
@@ -5,13 +5,15 @@ module Lib
 
 import Lattest.Model.Alphabet(IOAct(..))
 import Lattest.Adapter.StandardAdapters(Adapter,connectJSONSocketAdapterAcceptingInputs,withQuiescenceMillis)
-import Lattest.Model.StandardAutomata(automaton, ioAlphabet, nonDetConcTransFromMRel,interpretQuiescentConcrete, atom, top, bot, (\/), (/\),)
+import Lattest.Model.StandardAutomata(automaton, ioAlphabet, nonDetConcTransFromMRel,interpretQuiescentConcrete, atom, top, (\/), (/\), FreeLattice,)
 import Lattest.Exec.StandardTestControllers
-import Lattest.Exec.Testing(TestController(..), Verdict(..), runTester)
+import Lattest.Exec.Testing(runTester)
 import Data.Aeson(FromJSON, ToJSON)
 import GHC.Generics (Generic)
 
 data GState = Q0G | Q1G | Q2G | Q3G | Q4G | Q5G | Q6G | Q7G | Q8G | Q9G | Q10G deriving (Eq, Ord, Show)
+
+q0G,q1G ,q2G ,q3G ,q4G ,q5G ,q6G ,q7G ,q8G ,q9G,q10G :: FreeLattice GState
 q0G = atom Q0G
 q1G = atom Q1G
 q2G = atom Q2G
@@ -58,12 +60,13 @@ testSelector = randomTestSelectorFromSeed 456 `untilCondition` stopAfterSteps nr
 someFunc :: IO ()
 --someFunc = withSocketsDo $ do
 someFunc = do
-    putStrLn $ "connecting..."
+    putStrLn "connecting..."
     adap <- connectJSONSocketAdapterAcceptingInputs :: IO (Adapter (IOAct GIn GOut) GIn) -- the adapter connects, with explicit typing because it should know how to parse incoming data
     imp <- withQuiescenceMillis 200 adap
     let model = interpretQuiescentConcrete sG
-    putStrLn $ "starting test..."
+    putStrLn "starting test..."
     (verdict, (observed, maybeMq)) <- runTester model testSelector imp
     putStrLn $ "verdict: " ++ show verdict
     putStrLn $ "observed: " ++ show observed
     putStrLn $ "final state: " ++ show maybeMq
+

--- a/examples/example-conjunction/stack.yaml
+++ b/examples/example-conjunction/stack.yaml
@@ -37,7 +37,7 @@ packages:
 # forks / in-progress versions pinned to a git hash. For example:
 #
 extra-deps:
-- ../../lattest-lib
+- lattest-lib-0.1.1
 # - acme-missiles-0.3
 # - git: https://github.com/commercialhaskell/stack.git
 #   commit: e7b331f14bcffb8367cd58fbfc8b40ec7642100a

--- a/examples/example-import-spec-export-results/src/Lib.hs
+++ b/examples/example-import-spec-export-results/src/Lib.hs
@@ -5,17 +5,19 @@ module Lib
 import Lattest.Model.Alphabet(IOAct(..))
 import Lattest.Adapter.StandardAdapters(Adapter,connectJSONSocketAdapterAcceptingInputs,withQuiescenceMillis)
 import Lattest.Model.StandardAutomata
-import Lattest.Exec.Testing(TestController(..), Verdict(..), runTester)
+import Lattest.Exec.Testing(runTester)
 import Lattest.Exec.StandardTestControllers
-import Lattest.Adapter.Adapter(send, Adapter(..), close, observe)
+import Lattest.Adapter.Adapter(Adapter(..), close)
 import Lattest.Util.ModelParsingUtils(dumpLTSdot, readAutFile)
 import Lattest.Util.ReportUtils(writeResults, flushResults, initResultsFile, TestResult(..))
-import Control.Monad (forM_, foldM)
+import Control.Monad (foldM)
 import qualified Data.Sequence as Seq
 
+nrSteps, nrTests, initialSeed :: Int
 nrSteps = 10
 nrTests = 12
 initialSeed = 111
+csvPath :: String
 csvPath = "results.csv"
 
 runMultipleTests :: IO ()
@@ -44,7 +46,7 @@ runMultipleTests = do
             -- Initialize CSV file for results (with default header)
             initResultsFile csvPath Nothing
             putStrLn "Starting tests..."
-            
+
             finalRevBuf <- foldM (\revBuf i -> do
                 putStrLn $ "\n--- Test #" ++ show i ++ " ---"
                 putStrLn "Connecting..."
@@ -55,14 +57,15 @@ runMultipleTests = do
                                 `observingOnly` printActions
                                 `observingOnly` traceObserver
                                 `andObserving` stateObserver
-                (verdict, (observed, maybeMq)) <- runTester model testSelector imp
+                (verdict, (observed, _)) <- runTester model testSelector imp
                 close adap
                 writeResults csvPath [TestResult i (show verdict) (show observed)] revBuf 5
-                ) (Seq.empty) [1..nrTests]
-            
+                ) Seq.empty [1..nrTests]
+
             putStrLn "\nAll tests completed."
             -- Flush any remaining results to CSV
             flushResults csvPath finalRevBuf
 
             -- Dump the DOT file with the specification
             dumpLTSdot "LTS.dot" transitions
+

--- a/examples/example-import-spec-export-results/stack.yaml
+++ b/examples/example-import-spec-export-results/stack.yaml
@@ -37,7 +37,7 @@ packages:
 # forks / in-progress versions pinned to a git hash. For example:
 #
 extra-deps:
-- ../../lattest-lib
+- lattest-lib-0.1.1
 # - acme-missiles-0.3
 # - git: https://github.com/commercialhaskell/stack.git
 #   commit: e7b331f14bcffb8367cd58fbfc8b40ec7642100a

--- a/examples/example-load-json-sts/src/Lib.hs
+++ b/examples/example-load-json-sts/src/Lib.hs
@@ -2,9 +2,6 @@ module Lib
     ( run
     ) where
 
-import qualified Lattest.SMT.Config as Config
-import qualified Lattest.SMT.SMT as SMT
-import qualified Data.Maybe as Maybe
 import           Lattest.Adapter.StandardAdapters
 import           Lattest.Model.Alphabet (IOSuspGateValue, GateValue)
 import           Lattest.Model.StandardAutomata
@@ -22,11 +19,7 @@ run = do
 
     let model = interpretSTSQuiescent sts initVal
 
-    let cfg = Config.changeLog Config.defaultConfig False
-        smtLog = Config.smtLog cfg
-        smtProc = Maybe.fromJust (Config.getProc cfg)
     putStrLn "starting SMT solver..."
-    smtRef <- SMT.createSMTRef smtProc smtLog
 
     putStrLn "connecting to SUT..."
     let quiescenceMillis = 300
@@ -43,7 +36,7 @@ run = do
         probabilityOfWaitForOutput = 0.0
         randomSeed = 456
         testSelector =
-            randomDataOrWaitForOutputTestSelectorFromSeed smtRef randomSeed probabilityOfWaitForOutput
+            randomDataOrWaitForOutputTestSelectorFromSeed randomSeed probabilityOfWaitForOutput
             `untilCondition` stopAfterSteps nrSteps
             `observingOnly` traceObserver
             `andObserving` stateObserver

--- a/examples/example-load-json-sts/stack.yaml
+++ b/examples/example-load-json-sts/stack.yaml
@@ -37,7 +37,7 @@ packages:
 # forks / in-progress versions pinned to a git hash. For example:
 #
 extra-deps:
-- ../../lattest-lib
+- lattest-lib-0.1.1
 # - acme-missiles-0.3
 # - git: https://github.com/commercialhaskell/stack.git
 #   commit: e7b331f14bcffb8367cd58fbfc8b40ec7642100a

--- a/examples/example-n-complete/package.yaml
+++ b/examples/example-n-complete/package.yaml
@@ -10,7 +10,7 @@ dependencies:
 - base >= 4.7 && < 5
 - lattest-lib >= 0.1.0.0
 - deepseq
-- containers == 0.6.8
+- containers >= 0.6.8
 
 ghc-options:
 - -Wall

--- a/examples/example-n-complete/src/Lib.hs
+++ b/examples/example-n-complete/src/Lib.hs
@@ -4,11 +4,9 @@ module Lib
     ) where
 
 import Lattest.Model.Alphabet(IOAct(..))
-import Lattest.Adapter.StandardAdapters(Adapter,connectJSONSocketAdapterAcceptingInputs,withQuiescenceMillis)
+import Lattest.Adapter.StandardAdapters(Adapter,connectJSONSocketAdapterAcceptingInputs)
 import Lattest.Model.StandardAutomata
 import Lattest.Model.Automaton(reachable)
-import Lattest.Exec.Testing(TestController(..), Verdict(..), runTester, Verdict(Pass))
-import Lattest.Exec.StandardTestControllers
 import qualified Lattest.Exec.StandardTestControllers.CompleteTestSuite as CTS
 import Control.DeepSeq(NFData)
 import GHC.Generics (Generic)

--- a/examples/example-n-complete/stack.yaml
+++ b/examples/example-n-complete/stack.yaml
@@ -37,7 +37,7 @@ packages:
 # forks / in-progress versions pinned to a git hash. For example:
 #
 extra-deps:
-- ../../lattest-lib
+- lattest-lib-0.1.1
 # - acme-missiles-0.3
 # - git: https://github.com/commercialhaskell/stack.git
 #   commit: e7b331f14bcffb8367cd58fbfc8b40ec7642100a

--- a/examples/example-sts/stack.yaml
+++ b/examples/example-sts/stack.yaml
@@ -37,7 +37,7 @@ packages:
 # forks / in-progress versions pinned to a git hash. For example:
 #
 extra-deps:
-- ../../lattest-lib
+- lattest-lib-0.1.1
 # - acme-missiles-0.3
 # - git: https://github.com/commercialhaskell/stack.git
 #   commit: e7b331f14bcffb8367cd58fbfc8b40ec7642100a

--- a/examples/example-template/src/Lib.hs
+++ b/examples/example-template/src/Lib.hs
@@ -5,7 +5,7 @@ module Lib
 import Lattest.Model.Alphabet(IOAct(..))
 import Lattest.Adapter.StandardAdapters(Adapter,connectJSONSocketAdapterAcceptingInputs,withQuiescenceMillis)
 import Lattest.Model.StandardAutomata
-import Lattest.Exec.Testing(TestController(..), Verdict(..), runTester, Verdict(Pass))
+import Lattest.Exec.Testing(runTester)
 import Lattest.Exec.StandardTestControllers
 --import Network.Socket(withSocketsDo)
 

--- a/examples/example-template/stack.yaml
+++ b/examples/example-template/stack.yaml
@@ -37,7 +37,7 @@ packages:
 # forks / in-progress versions pinned to a git hash. For example:
 #
 extra-deps:
-- ../../lattest-lib
+- lattest-lib-0.1.1
 # - acme-missiles-0.3
 # - git: https://github.com/commercialhaskell/stack.git
 #   commit: e7b331f14bcffb8367cd58fbfc8b40ec7642100a

--- a/lattest-lib/test/Test/Lattest/Model/STSTest.hs
+++ b/lattest-lib/test/Test/Lattest/Model/STSTest.hs
@@ -250,17 +250,17 @@ getSTSIntrpStateFloat loc val = disjunction [IntrpState loc $ fromConstantsMap $
 
 testSTSHappyFlowFloat :: Test
 testSTSHappyFlowFloat = TestCase $ do
-    -- assertEqual "\ninitial state " (getSTSIntrpStateFloat 0 0.0) (stateConf stsExampleIntrpr)
+    assertEqual "\ninitial state " (getSTSIntrpStateFloat 0 0.0) (stateConf stsExampleIntrprFloat)
     let intrp2 = after stsExampleIntrprFloat (GateValue (In "water") [Cfloat (7.5 :: Double)])
     assertEqual "after water 7.5: " (getSTSIntrpStateFloat 1 (7.5 :: Double)) (stateConf intrp2)
-    -- let intrp3 = after intrp2 (GateValue (Out "ok") [Cfloat 7.5])
-    -- assertEqual "after ok 7.5: " (getSTSIntrpStateFloat 0 (7.5 :: Double)) (stateConf intrp3)
-    -- let intrp4 = after intrp3 (GateValue (In "water") [Cfloat 8.5])
-    -- assertEqual "after water 8.5: " (getSTSIntrpStateFloat 1 (16.0 :: Double)) (stateConf intrp4)
-    -- let intrp5 = after intrp4 (GateValue (Out "ok") [Cfloat 16.0])
-    -- assertEqual "after ok 16.0: " (getSTSIntrpStateFloat 0 (16.0 :: Double)) (stateConf intrp5)
-    -- let intrp6 = after intrp5 (GateValue (Out "coffee") [])
-    -- assertEqual "after coffee: " (getSTSIntrpStateFloat 2 (16.0 :: Double)) (stateConf intrp6)
+    let intrp3 = after intrp2 (GateValue (Out "ok") [Cfloat 7.5])
+    assertEqual "after ok 7.5: " (getSTSIntrpStateFloat 0 (7.5 :: Double)) (stateConf intrp3)
+    let intrp4 = after intrp3 (GateValue (In "water") [Cfloat 8.5])
+    assertEqual "after water 8.5: " (getSTSIntrpStateFloat 1 (16.0 :: Double)) (stateConf intrp4)
+    let intrp5 = after intrp4 (GateValue (Out "ok") [Cfloat 16.0])
+    assertEqual "after ok 16.0: " (getSTSIntrpStateFloat 0 (16.0 :: Double)) (stateConf intrp5)
+    let intrp6 = after intrp5 (GateValue (Out "coffee") [])
+    assertEqual "after coffee: " (getSTSIntrpStateFloat 2 (16.0 :: Double)) (stateConf intrp6)
     return()
 
 


### PR DESCRIPTION
See #68: this PR uses the hackage release in the examples (which makes them more self-contained / better examples for how to use lattest, but arguably makes it harder for us to run them on local changes), and makes some changes to them (mainly to adjust for the SBV migration).

The changes to the tests I'd like to merge, the changes to the stack.yamls is up for discussion:
- For CI, it's fairly easy to make a script that runs the examples using the PR regardless of what we have in the stack.yamls
- For users / stability, it might be better to have them refer to Hackage
- For local testing while hacking on lattest, it's significantly easier if they refer to '../../lattest-lib', and it'll be easy to forget to make that change.