### PR TITLE
Ci/add examples to ci

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -17,6 +17,7 @@ jobs:
     name: testsuite
 
     runs-on: ubuntu-latest
+    timeout-minutes: 45
 
     steps:
     - uses: actions/checkout@v4
@@ -77,3 +78,78 @@ jobs:
       run: |
         cd lattest-lib
         stack test --system-ghc --stack-yaml "stack-${{ matrix.ghcversion }}.yaml"
+
+    - name: Set up JDK for example SUTs
+      uses: actions/setup-java@v4
+      with:
+        distribution: temurin
+        java-version: '21'
+        cache: maven
+
+    - name: Point examples at the local lattest-lib build
+      run: |
+        set -euo pipefail
+        resolver_line=$(grep '^resolver:' "lattest-lib/stack-${{ matrix.ghcversion }}.yaml")
+        for exdir in examples/*/; do
+          ex=$(basename "$exdir")
+          [ -f "$exdir/stack.yaml" ] || continue
+          sed -i -E \
+            -e "s|^resolver:.*|$resolver_line|" \
+            -e "s|^- lattest-lib-[0-9]+(\.[0-9]+)*\$|- ../../lattest-lib|" \
+            "$exdir/stack.yaml"
+        done
+
+    - name: Run examples against their Java SUTs
+      run: |
+        set -uo pipefail
+        for exdir in examples/*/; do
+          ex=$(basename "$exdir")
+          [ -f "$exdir/stack.yaml" ] || continue
+          echo "::group::$ex"
+          sut_log="$RUNNER_TEMP/$ex-sut.log"
+          sut_pid=""
+
+          if [ -f "$exdir/sut/pom.xml" ]; then
+            timeout -k 30 300 bash -c 'cd "$1/sut" && mvn -q -B install' _ "$exdir"
+            if [ $? -ne 0 ]; then
+              echo "::endgroup::"
+              echo "Building the SUT for $ex failed"
+              exit 1
+            fi
+
+            (cd "$exdir/sut" && mvn -q -B exec:java > "$sut_log" 2>&1) &
+            sut_pid=$!
+
+            ready=0
+            for i in $(seq 1 30); do
+              if (exec 3<>/dev/tcp/127.0.0.1/2929) 2>/dev/null; then
+                exec 3<&- 3>&-
+                ready=1
+                break
+              fi
+              sleep 1
+            done
+            if [ "$ready" -ne 1 ]; then
+              echo "SUT for $ex never opened port 2929"
+              cat "$sut_log" || true
+              kill -9 "$sut_pid" 2>/dev/null || true
+              echo "::endgroup::"
+              exit 1
+            fi
+          fi
+
+          timeout -k 30 600 bash -c 'cd "$1" && stack build --system-ghc --stack-yaml stack.yaml && stack run --system-ghc --stack-yaml stack.yaml' _ "$exdir"
+          status=$?
+
+          if [ -n "$sut_pid" ]; then
+            kill -9 "$sut_pid" 2>/dev/null || true
+            wait "$sut_pid" 2>/dev/null || true
+          fi
+          echo "::endgroup::"
+
+          if [ "$status" -ne 0 ]; then
+            echo "Example $ex failed"
+            [ -f "$sut_log" ] && cat "$sut_log"
+            exit 1
+          fi
+        done

--- a/examples/example-n-complete/package.yaml
+++ b/examples/example-n-complete/package.yaml
@@ -10,7 +10,7 @@ dependencies:
 - base >= 4.7 && < 5
 - lattest-lib >= 0.1.0.0
 - deepseq
-- containers == 0.6.8
+- containers >= 0.6.8
 
 ghc-options:
 - -Wall

--- a/lattest-lib/CHANGELOG.md
+++ b/lattest-lib/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to the
 
 ## Unreleased
 
+## 0.1.1 - 2026-07-15
+Bugfix patch: adds instance OrdTraversable FreeLattice, and properly kills the reading thread before its socket is closed.
+
 ## 0.1.0.0 - 2026-07-14
 First release
 

--- a/lattest-lib/make-release.md
+++ b/lattest-lib/make-release.md
@@ -1,4 +1,8 @@
-- Check the changelog, increment version number, check version bounds on dependencies, etc.
+# Check:
+- changelog
+- increment version number
+- version bounds on dependencies
+- run the examples
 
 # HACKAGE:
 - Make an updated lattest-lib.cabal (e.g. by invoking stack)

--- a/lattest-lib/package.yaml
+++ b/lattest-lib/package.yaml
@@ -1,5 +1,5 @@
 name:                lattest-lib
-version:             0.1.0.0
+version:             0.1.1
 synopsis: Model-based testing framework
 description: |
   Welcome to Lattest, the latest attested lattice testing tech!

--- a/lattest-lib/src/Lattest/Adapter/StandardAdapters.hs
+++ b/lattest-lib/src/Lattest/Adapter/StandardAdapters.hs
@@ -74,7 +74,7 @@ import Data.Time.Clock(getCurrentTime,addUTCTime,diffUTCTime,NominalDiffTime,sec
 
 import Debug.Trace(trace) -- FIXME find a better alternative
 
-import GHC.Conc(forkIO, newTVarIO, TVar, retry, atomically, writeTVar, readTVar, STM, orElse)
+import GHC.Conc(forkIO, newTVarIO, TVar, retry, atomically, writeTVar, readTVar, STM, orElse, killThread)
 
 import Network.Socket(HostName, PortNumber)
 import Network.Utils (niceSocketsDo, connectTCP)
@@ -566,11 +566,12 @@ connectSocketAdapterWith :: SocketSettings act i -> IO (Adapter ByteString ByteS
 connectSocketAdapterWith settings = niceSocketsDo $ do
     socket <- connectTCP (hostName settings) (portNumber settings)
     (actionBytes, inputCommandBytes) <- socketToStreams socket
-    forkedActionBytes <- fromInputStreamBuffered actionBytes
+    (threadid, forkedActionBytes) <- fromInputStreamBuffered actionBytes
     return $ Adapter {
         inputCommandsToSut = inputCommandBytes,
         actionsFromSut = forkedActionBytes,
-        close = Socket.gracefulClose socket 1000
+        -- when the adapter is closed, we first kill the thread, to prevent it from throwing errors when we kill its socket
+        close = killThread threadid >> Socket.gracefulClose socket 1000
     }
 
 -- | Create an adapter by connecting to a server socket, with the default settings, and sending inputs and reading outputs in JSON format.

--- a/lattest-lib/src/Lattest/Model/BoundedMonad.hs
+++ b/lattest-lib/src/Lattest/Model/BoundedMonad.hs
@@ -190,6 +190,10 @@ isProperSupersetOfAny sets a = any (isProperSupersetOf a) (Set.toList sets)
 instance OM.OrdFunctor FreeLattice where
     ordMap f (FreeLattice x) = FreeLattice $ Set.map (Set.map f) x
 
+instance OM.OrdTraversable FreeLattice where
+    ordTraverse f (FreeLattice x) = FreeLattice <$> ordTraverse (ordTraverse f) x
+    ordSequenceA (FreeLattice x) = FreeLattice <$> ordTraverse ordSequenceA x
+
 instance Ord a => JoinSemiLattice (FreeLattice a) where
     (FreeLattice x) \/ (FreeLattice y) = FreeLattice $ Set.map Set.unions $ nAryCartesianProduct $ Set.fromList [x,y]
 

--- a/lattest-lib/src/Lattest/Streams/Synchronized.hs
+++ b/lattest-lib/src/Lattest/Streams/Synchronized.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TupleSections #-}
 module Lattest.Streams.Synchronized (
 TInputStream,
 read,
@@ -26,16 +27,14 @@ import Control.Concurrent.STM(STM, retry)
 import Control.Concurrent.STM.TQueue(TQueue, newTQueueIO, writeTQueue, readTQueue, isEmptyTQueue, unGetTQueue)
 import Control.Concurrent.STM.TMVar(TMVar, takeTMVar, isEmptyTMVar)
 import Control.Concurrent.STM.TVar(newTVarIO, readTVar, writeTVar)
-import GHC.IO.Exception (ioe_location, ioe_errno)
-import Control.Exception(throwIO, Exception, catchJust)
+import Control.Exception(throwIO, Exception)
 import Control.Monad (void, when)
 import Data.List(singleton)
 
-import GHC.Conc (atomically, forkIO)
+import GHC.Conc (atomically, forkIO, ThreadId)
 import System.IO.Streams (InputStream, OutputStream, makeOutputStream, connect)
 import qualified System.IO.Streams as Streams (write)
 import Control.Monad.Extra((||^))
-import Foreign.C.Error (eBADF, Errno (Errno))
 
 data TInputStream a = TInputStream {
     tRead :: STM (Maybe a),
@@ -141,22 +140,12 @@ fromBuffer buffer = withClosedState $ TInputStream {
 
 -- a synchronized input stream that reads from the given input stream. A monitoring thread reads the given input stream and buffers the inputs on the background
 -- TODO support a bound for the buffer
-fromInputStreamBuffered :: InputStream a -> IO (TInputStream a)
+fromInputStreamBuffered :: InputStream a -> IO (ThreadId, TInputStream a)
 fromInputStreamBuffered is = do
     buffer <- newTQueueIO
     bufferOS <- makeOutputStream $ atomically . writeTQueue buffer -- an intermediate output stream to write to the queue
-    void $ forkIO $ catchSocketClosed $ connect is bufferOS -- move items from the original adapter into the buffer in a separate thread
-    fromBuffer buffer
- where
-   -- catches "threadWait: invalid argument (Bad file descriptor)"
-   -- which is thrown when the socket is closed while this thread is running, e.g. on Adaptor.close()
-   -- The alternative solution is to keep track of the threadID given by forkIO,
-   -- and explicitly stop the thread before closing the socket.
-   catchSocketClosed forkedThread = catchJust threadwaitinvalid forkedThread pure
-   threadwaitinvalid e
-    | ioe_location e == "threadWait"
-    , fmap Errno (ioe_errno e) == Just eBADF = Just ()
-    | otherwise = Nothing
+    threadid <- forkIO $ connect is bufferOS -- move items from the original adapter into the buffer in a separate thread
+    (threadid,) <$> fromBuffer buffer
 
 mapUnbuffered :: (a -> b) -> (b -> a) -> TInputStream a -> TInputStream b -- we need an inverse to push a's back to the original TInputStream of b's
 mapUnbuffered f f' tis = TInputStream { -- FIXME either remove or wrap in withClosedState

--- a/lattest-lib/test/Test/Lattest/Model/STSTest.hs
+++ b/lattest-lib/test/Test/Lattest/Model/STSTest.hs
@@ -250,17 +250,17 @@ getSTSIntrpStateFloat loc val = disjunction [IntrpState loc $ fromConstantsMap $
 
 testSTSHappyFlowFloat :: Test
 testSTSHappyFlowFloat = TestCase $ do
-    -- assertEqual "\ninitial state " (getSTSIntrpStateFloat 0 0.0) (stateConf stsExampleIntrpr)
+    assertEqual "\ninitial state " (getSTSIntrpStateFloat 0 0.0) (stateConf stsExampleIntrprFloat)
     let intrp2 = after stsExampleIntrprFloat (GateValue (In "water") [Cfloat (7.5 :: Double)])
     assertEqual "after water 7.5: " (getSTSIntrpStateFloat 1 (7.5 :: Double)) (stateConf intrp2)
-    -- let intrp3 = after intrp2 (GateValue (Out "ok") [Cfloat 7.5])
-    -- assertEqual "after ok 7.5: " (getSTSIntrpStateFloat 0 (7.5 :: Double)) (stateConf intrp3)
-    -- let intrp4 = after intrp3 (GateValue (In "water") [Cfloat 8.5])
-    -- assertEqual "after water 8.5: " (getSTSIntrpStateFloat 1 (16.0 :: Double)) (stateConf intrp4)
-    -- let intrp5 = after intrp4 (GateValue (Out "ok") [Cfloat 16.0])
-    -- assertEqual "after ok 16.0: " (getSTSIntrpStateFloat 0 (16.0 :: Double)) (stateConf intrp5)
-    -- let intrp6 = after intrp5 (GateValue (Out "coffee") [])
-    -- assertEqual "after coffee: " (getSTSIntrpStateFloat 2 (16.0 :: Double)) (stateConf intrp6)
+    let intrp3 = after intrp2 (GateValue (Out "ok") [Cfloat 7.5])
+    assertEqual "after ok 7.5: " (getSTSIntrpStateFloat 0 (7.5 :: Double)) (stateConf intrp3)
+    let intrp4 = after intrp3 (GateValue (In "water") [Cfloat 8.5])
+    assertEqual "after water 8.5: " (getSTSIntrpStateFloat 1 (16.0 :: Double)) (stateConf intrp4)
+    let intrp5 = after intrp4 (GateValue (Out "ok") [Cfloat 16.0])
+    assertEqual "after ok 16.0: " (getSTSIntrpStateFloat 0 (16.0 :: Double)) (stateConf intrp5)
+    let intrp6 = after intrp5 (GateValue (Out "coffee") [])
+    assertEqual "after coffee: " (getSTSIntrpStateFloat 2 (16.0 :: Double)) (stateConf intrp6)
     return()
 
 


### PR DESCRIPTION
Added some steps to execute examples in the CI. Some notes:
- The lattest-lib hackage version is replaced by ../../lattest-lib. To do this, there is a simple regex that matches **any** version. Ideally, we should do this based on VERSION instead, but we should have a CI for releases that updates all versions first.
- There is a timeout for the examples of 600 seconds and overall 45 minutes to the whole thing, to avoid spending 6 hours (GitHub actions default) if something crashes. 
- The CI fails if any of the examples fails to build or crashes during execution, but it is agnostic of the testing verdict itself.
- The GHC version in the examples' stack.yml file is overriden with the GHC version used for building lattest, for consistency. Examples are executed for all 3 versions.